### PR TITLE
Fixing a missing dependency on keyboard_generate_messages_cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ target_link_libraries(${PROJECT_NAME}
   ${PROJECT_NAME}_manual_tf_alignment
   ${catkin_LIBRARIES}
 )
+add_dependencies(${PROJECT_NAME}_manual_tf_alignment keyboard_generate_messages_cpp)
 
 # Executable
 add_executable(${PROJECT_NAME}_demo_tf_listener


### PR DESCRIPTION
This would cause tf_keyboard_cal to build before a required autogenerated header file was available.